### PR TITLE
Add hscpp-mem library, which wraps underlying memory with a Ref type.…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,18 +4,20 @@ project(hscpp)
 
 # Options:
 #     - HSCPP_BUILD_EXAMPLES: Build demos in the examples directory.
-#     - HSCPP_BUILD_TESTs: Build tests in the test directory.
+#     - HSCPP_BUILD_TESTS: Build tests in the test directory.
+#     - HSCPP_BUILD_EXTENSION_MEM: Build hscpp::mem extension, creating hscpp-mem library.
 #     - HSCPP_USE_GHC_FILESYSTEM: Usg ghc filesystem in place of std::filesystem. This is done
 #       implicitly if CMAKE_CXX_STANDARD < 17.
 #     - HSCPP_DISABLE: Disable hscpp completely. Hotswapper function calls will have no effect,
 #       and no object will be tracked.
 option(HSCPP_BUILD_EXAMPLES "Enable building examples." ON)
 option(HSCPP_BUILD_TESTS "Enable building tests." ON)
+option(HSCPP_BUILD_EXTENSION_MEM "Enable building hscpp::mem extension." ON)
 option(HSCPP_USE_GHC_FILESYSTEM "Use ghc filesystem as a substitute of std::filesystem." OFF)
 option(HSCPP_DISABLE "Disable hscpp." OFF)
 
 # List of source files compiled in every configuration.
-list(APPEND SRC_FILES
+list(APPEND HSCPP_SRC_FILES
     src/compiler/Compiler.cpp
     src/compiler/CompilerCmdLine_gcc.cpp
     src/compiler/CompilerInitializeTask_gcc.cpp
@@ -85,26 +87,26 @@ list(APPEND SRC_FILES
 )
 
 # List of compile options in every configuration.
-list(APPEND COMPILE_OPTIONS)
+list(APPEND HSCPP_COMPILE_OPTIONS)
 
 # List of compile definitions in every configuration.
-list(APPEND COMPILE_DEFINITIONS
+list(APPEND HSCPP_COMPILE_DEFINITIONS
     HSCPP_ROOT_PATH="${CMAKE_CURRENT_SOURCE_DIR}"
     HSCPP_COMPILER_PATH="${CMAKE_CXX_COMPILER}"
     HSCPP_BUILD_PATH="${CMAKE_BINARY_DIR}"
 )
 
 # List of libraries to link in every configuration.
-list(APPEND LINK_LIBRARIES)
+list(APPEND HSCPP_LINK_LIBRARIES)
 
 # Additional compile definitions in Debug.
-list(APPEND COMPILE_DEFINITIONS
+list(APPEND HSCPP_COMPILE_DEFINITIONS
     $<$<CONFIG:Debug>:HSCPP_DEBUG>
 )
 
 # OS-specific settings.
 if (WIN32)
-    list(APPEND SRC_FILES
+    list(APPEND HSCPP_SRC_FILES
         src/cmd-shell/CmdShell_win32.cpp
         src/compiler/CompilerCmdLine_msvc.cpp
         src/compiler/CompilerInitializeTask_msvc.cpp
@@ -116,12 +118,12 @@ if (WIN32)
         include/hscpp/file-watcher/FileWatcher_win32.h
     )
 
-    list(APPEND COMPILE_DEFINITIONS
+    list(APPEND HSCPP_COMPILE_DEFINITIONS
         HSCPP_PLATFORM_WIN32
         _CRT_SECURE_NO_WARNINGS
     )
 elseif(APPLE)
-    list(APPEND SRC_FILES
+    list(APPEND HSCPP_SRC_FILES
         src/cmd-shell/CmdShell_unix.cpp
         src/file-watcher/FileWatcher_apple.cpp
 
@@ -129,17 +131,17 @@ elseif(APPLE)
         include/hscpp/file-watcher/FileWatcher_apple.h
     )
 
-    list(APPEND COMPILE_DEFINITIONS
+    list(APPEND HSCPP_COMPILE_DEFINITIONS
         HSCPP_PLATFORM_APPLE
         HSCPP_PLATFORM_UNIX
     )
 
     find_library(CORE_SERVICES CoreServices)
-    list(APPEND LINK_LIBRARIES
+    list(APPEND HSCPP_LINK_LIBRARIES
         ${CORE_SERVICES}
     )
 elseif(UNIX)
-    list(APPEND SRC_FILES
+    list(APPEND HSCPP_SRC_FILES
         src/cmd-shell/CmdShell_unix.cpp
         src/file-watcher/FileWatcher_unix.cpp
 
@@ -147,11 +149,11 @@ elseif(UNIX)
         include/hscpp/file-watcher/FileWatcher_unix.h
     )
 
-    list(APPEND COMPILE_DEFINITIONS
+    list(APPEND HSCPP_COMPILE_DEFINITIONS
         HSCPP_PLATFORM_UNIX
     )
 
-    list(APPEND LINK_LIBRARIES
+    list(APPEND HSCPP_LINK_LIBRARIES
         dl
         uuid
     )
@@ -159,13 +161,13 @@ endif()
 
 # Compiler-specific settings.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    list(APPEND COMPILE_OPTIONS
+    list(APPEND HSCPP_COMPILE_OPTIONS
         /permissive # Enforce standard compliance.
     )
 
-    list(APPEND COMPILE_DEFINITIONS HSCPP_COMPILER_MSVC)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_COMPILER_MSVC)
 elseif (NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC") # Exclude clang-cl.
-    list(APPEND COMPILE_OPTIONS
+    list(APPEND HSCPP_COMPILE_OPTIONS
         -Wall
         -Wextra
         -Wshadow
@@ -174,20 +176,20 @@ elseif (NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC") # Exclude clang-cl.
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") # cl
-    list(APPEND COMPILE_DEFINITIONS HSCPP_COMPILER_MSVC)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_COMPILER_MSVC)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC") # clang-cl
-    list(APPEND COMPILE_OPTIONS
+    list(APPEND HSCPP_COMPILE_OPTIONS
         /EHsc # Use standard exception handling.
     )
 
-    list(APPEND COMPILE_DEFINITIONS HSCPP_COMPILER_CLANG_CL)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_COMPILER_CLANG_CL)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") # clang
-    list(APPEND COMPILE_DEFINITIONS
+    list(APPEND HSCPP_COMPILE_DEFINITIONS
         HSCPP_COMPILER_CLANG
         HSCPP_COMPILER_GCC # clang has a gcc-like interface, and can be treated like g++ when invoked.
     )
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # g++
-    list(APPEND COMPILE_DEFINITIONS HSCPP_COMPILER_GCC)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_COMPILER_GCC)
 else()
     message(WARNING "Compiler is not officially supported.")
 endif()
@@ -199,10 +201,10 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)
 elseif(CMAKE_CXX_STANDARD LESS 11)
-    message(FATAL_ERROR "hotswap-cpp requires C++11.")
+    message(FATAL_ERROR "hscpp requires C++11.")
 endif()
 
-list(APPEND COMPILE_DEFINITIONS
+list(APPEND HSCPP_COMPILE_DEFINITIONS
     HSCPP_CXX_STANDARD=${CMAKE_CXX_STANDARD}
 )
 
@@ -216,8 +218,8 @@ if (HSCPP_USE_GHC_FILESYSTEM OR (CMAKE_CXX_STANDARD LESS 17))
         message(STATUS "Using ghc filesystem rather than std::filesystem.")
     endif()
 
-    list(APPEND LINK_LIBRARIES ghc_filesystem)
-    list(APPEND COMPILE_DEFINITIONS HSCPP_USE_GHC_FILESYSTEM)
+    list(APPEND HSCPP_LINK_LIBRARIES ghc_filesystem)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_USE_GHC_FILESYSTEM)
 
     add_subdirectory(lib/filesystem-1.3.4)
 
@@ -227,18 +229,18 @@ endif()
 
 # Toggle if hscpp is enabled or disabled.
 if (HSCPP_DISABLE)
-    list(APPEND SRC_FILES src/Hotswapper_disabled.cpp)
-    list(APPEND COMPILE_DEFINITIONS HSCPP_DISABLE)
+    list(APPEND HSCPP_SRC_FILES src/Hotswapper_disabled.cpp)
+    list(APPEND HSCPP_COMPILE_DEFINITIONS HSCPP_DISABLE)
 else()
-    list(APPEND SRC_FILES src/Hotswapper_enabled.cpp)
+    list(APPEND HSCPP_SRC_FILES src/Hotswapper_enabled.cpp)
 endif()
 
-add_library(hscpp ${SRC_FILES})
+add_library(hscpp ${HSCPP_SRC_FILES})
 
 target_include_directories(hscpp PUBLIC include)
-target_compile_options(hscpp PUBLIC ${COMPILE_OPTIONS})
-target_compile_definitions(hscpp PUBLIC ${COMPILE_DEFINITIONS})
-target_link_libraries(hscpp ${LINK_LIBRARIES})
+target_compile_options(hscpp PUBLIC ${HSCPP_COMPILE_OPTIONS})
+target_compile_definitions(hscpp PUBLIC ${HSCPP_COMPILE_DEFINITIONS})
+target_link_libraries(hscpp ${HSCPP_LINK_LIBRARIES})
 
 if (HSCPP_BUILD_EXAMPLES)
     add_subdirectory(examples)
@@ -246,4 +248,8 @@ endif()
 
 if (HSCPP_BUILD_TESTS)
     add_subdirectory(test)
+endif()
+
+if (HSCPP_BUILD_EXTENSION_MEM)
+    add_subdirectory(extensions/mem)
 endif()

--- a/extensions/mem/CMakeLists.txt
+++ b/extensions/mem/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(hscpp-mem
+    src/MemoryManager.cpp
+
+    include/hscpp/mem/IMemoryManager.h
+    include/hscpp/mem/MemoryManager.h
+    include/hscpp/mem/Ref.h
+)
+
+target_include_directories(hscpp-mem
+    PUBLIC
+        include
+    PRIVATE
+        ../../include
+)

--- a/extensions/mem/include/hscpp/mem/IMemoryManager.h
+++ b/extensions/mem/include/hscpp/mem/IMemoryManager.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace hscpp { namespace mem {
+
+    // Use an IMemoryManager to avoid circular dependency between Ref and MemoryManager.
+    class IMemoryManager
+    {
+    public:
+        // An invalid ID, which should be treated like a nullptr.
+        constexpr static size_t INVALID_ID = (std::numeric_limits<size_t>::max)();
+
+        // The MemoryManager can return a reference to itself, which has this ID.
+        constexpr static size_t MEMORY_MANAGER_ID = (std::numeric_limits<size_t>::max)() - 1;
+
+        virtual ~IMemoryManager() = default;
+        virtual uint8_t* GetMemory(uint64_t id) = 0;
+        virtual void FreeBlock(uint64_t id) = 0;
+    };
+
+}}

--- a/extensions/mem/include/hscpp/mem/MemoryManager.h
+++ b/extensions/mem/include/hscpp/mem/MemoryManager.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <limits>
+
+#include "hscpp/module/IAllocator.h"
+#include "hscpp/module/AllocationResolver.h"
+#include "hscpp/mem/Ref.h"
+#include "hscpp/mem/IMemoryManager.h"
+
+namespace hscpp { namespace mem {
+
+    class MemoryManager : public IMemoryManager, public IAllocator
+    {
+        // Use the Create() function to make a new MemoryManager.
+        MemoryManager(const MemoryManager&) = delete;
+
+    public:
+        struct Config
+        {
+            Config();
+
+            AllocationResolver* pAllocationResolver = nullptr;
+
+            // Number of Blocks to reserve on initialization.
+            uint64_t reservedBlocks = 100;
+
+            // Overridable Allocate/Free functions.
+            std::function<uint8_t*(uint64_t size)> AllocateCb;
+            std::function<void(uint8_t* pMemory)> FreeCb;
+        };
+
+        static UniqueRef<MemoryManager> Create(const Config& config = Config());
+
+        template <typename T>
+        UniqueRef<T> Allocate();
+
+        // Free is handled by the UniqueRef when it goes out of scope. The UniqueRef will handle
+        // calling the destructor.
+
+        uint64_t GetNumBlocks() const;
+
+    private:
+        struct BlockHeader
+        {
+            uint64_t iBlock = INVALID_ID;
+        };
+
+        struct Block
+        {
+            // Get BlockHeader at location: pMemory - sizeof(BlockHeader)
+            uint8_t* pMemory = nullptr;
+        };
+
+        AllocationResolver* m_pAllocationResolver = nullptr;
+
+        std::function<uint8_t*(uint64_t size)> m_AllocateCb;
+        std::function<void(uint8_t* pMemory)> m_FreeCb;
+
+        std::vector<Block> m_Blocks;
+
+        uint64_t m_iFreeBlocksBegin = 0;
+        std::vector<uint64_t> m_FreeBlockIndices;
+        std::vector<uint64_t> m_FreeBlockIndexByBlock;
+
+        MemoryManager() = default;
+
+        // hscpp::mem::IMemoryManager
+        // Used by Ref to get underlying memory for a given id. Note that the returned pointer
+        // may change for the same id, should a runtime swap take place.
+        uint8_t* GetMemory(uint64_t id) override;
+        void FreeBlock(uint64_t iBlock) override;
+
+        // hscpp::IAllocator
+        AllocationInfo Hscpp_Allocate(uint64_t size) override;
+        AllocationInfo Hscpp_AllocateSwap(uint64_t previousId, uint64_t size) override;
+        uint64_t Hscpp_FreeSwap(uint8_t* pMemory) override;
+
+        // Helper methods
+        uint8_t* AllocateBlock(uint64_t size, uint64_t iBlock);
+        uint64_t ReserveFirstFreeBlock();
+    };
+
+    template<typename T>
+    UniqueRef<T> MemoryManager::Allocate()
+    {
+        UniqueRef<T> ref;
+        uint64_t iBlock = IMemoryManager::INVALID_ID;
+
+        if (m_pAllocationResolver != nullptr)
+        {
+            // hscpp is active, allocate through the hscpp::AllocationResolver. This will ultimately
+            // call back into this class, through Hscpp_Allocate.
+            AllocationInfo info;
+            m_pAllocationResolver->Allocate<T>(info);
+            iBlock = info.id;
+        }
+        else
+        {
+            // hscpp is inactive, allocate directly.
+            uint64_t size = sizeof(typename std::aligned_storage<sizeof(T)>::type);
+
+            iBlock = ReserveFirstFreeBlock();
+            uint8_t* pMemory = AllocateBlock(size, iBlock);
+            new (pMemory) T;
+        }
+
+        ref.m_Id = iBlock;
+        ref.m_pMemoryManager = this;
+        return ref;
+    }
+
+}}

--- a/extensions/mem/include/hscpp/mem/Ref.h
+++ b/extensions/mem/include/hscpp/mem/Ref.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "hscpp/mem/IMemoryManager.h"
+
+namespace hscpp { namespace mem {
+
+    template <typename T>
+    class Ref
+    {
+        friend class MemoryManager;
+
+    public:
+        T* operator->() const
+        {
+            return GetMemory();
+        }
+
+        T* operator*() const
+        {
+            return GetMemory();
+        }
+
+        T* operator&() const
+        {
+            return GetMemory();
+        }
+
+    protected:
+        uint64_t m_Id = IMemoryManager::INVALID_ID;
+        IMemoryManager* m_pMemoryManager = nullptr;
+
+        // Throws an std::runtime_error on a nullptr access. This makes it possible to catch
+        // a null dereference on Linux and macOS with the hscpp::DoProtectedCall wrapper, and fix
+        // the error during runtime (on Windows, a nullptr exception can always be caught).
+        T* GetMemory() const
+        {
+            if (m_pMemoryManager == nullptr)
+            {
+                throw std::runtime_error("Ref is null (MemoryManager == nullptr).");
+            }
+
+            T* pT = reinterpret_cast<T*>(m_pMemoryManager->GetMemory(m_Id));
+            if (pT == nullptr)
+            {
+                throw std::runtime_error("Ref is null.");
+            }
+
+            return pT;
+        }
+
+        // No std::runtime_error throw on a nullptr access.
+        T* GetMemoryUnsafe() const
+        {
+            if (m_pMemoryManager == nullptr)
+            {
+                return nullptr;
+            }
+
+            return reinterpret_cast<T*>(m_pMemoryManager->GetMemory(m_Id));
+        }
+
+    };
+
+    template <typename T>
+    class UniqueRef : public Ref<T>
+    {
+        friend class MemoryManager;
+
+        // Do not allow copy.
+        UniqueRef(const UniqueRef<T>& rhs) = delete;
+        UniqueRef<T>& operator=(const UniqueRef<T>& rhs) = delete;
+
+    public:
+        UniqueRef() = default;
+
+        UniqueRef(UniqueRef<T>&& rhs) noexcept
+        {
+            MoveRef(std::move(rhs));
+        }
+
+        UniqueRef<T>& operator=(UniqueRef<T>&& rhs) noexcept
+        {
+            Free();
+            MoveRef(std::move(rhs));
+            return *this;
+        }
+
+        void Free()
+        {
+            if (this->m_Id == IMemoryManager::MEMORY_MANAGER_ID)
+            {
+                // This Ref refers to the MemoryManager itself. Do a normal delete, as the
+                // MemoryManager will allocate no Block for its own instance.
+                delete this->m_pMemoryManager;
+                this->m_pMemoryManager = nullptr;
+            }
+            else
+            {
+                // Free memory, unless this Ref is a nullptr (double-freeing a Ref is safe).
+                T* pSelf = this->GetMemoryUnsafe();
+                if (pSelf != nullptr)
+                {
+                    pSelf->~T();
+                    this->m_pMemoryManager->FreeBlock(this->m_Id);
+                }
+            }
+
+            this->m_Id = IMemoryManager::INVALID_ID;
+        }
+
+        ~UniqueRef()
+        {
+            Free();
+        }
+
+    private:
+        void MoveRef(UniqueRef<T>&& rhs) noexcept
+        {
+            this->m_Id = rhs.m_Id;
+            this->m_pMemoryManager = rhs.m_pMemoryManager;
+
+            rhs.m_Id = IMemoryManager::INVALID_ID;
+            rhs.m_pMemoryManager = nullptr;
+        }
+    };
+
+}}

--- a/extensions/mem/src/MemoryManager.cpp
+++ b/extensions/mem/src/MemoryManager.cpp
@@ -1,0 +1,145 @@
+#include "hscpp/mem/MemoryManager.h"
+
+namespace hscpp { namespace mem {
+
+    UniqueRef<MemoryManager> MemoryManager::Create(const Config& config /*=Config()*/)
+    {
+        MemoryManager* pMemoryManager = new MemoryManager();
+        pMemoryManager->m_pAllocationResolver = config.pAllocationResolver;
+        pMemoryManager->m_AllocateCb = config.AllocateCb;
+        pMemoryManager->m_FreeCb = config.FreeCb;
+        pMemoryManager->m_Blocks.reserve(config.reservedBlocks);
+        pMemoryManager->m_FreeBlockIndices.reserve(config.reservedBlocks);
+        pMemoryManager->m_FreeBlockIndexByBlock.reserve(config.reservedBlocks);
+
+        UniqueRef<MemoryManager> ref;
+        ref.m_pMemoryManager = pMemoryManager;
+        ref.m_Id = IMemoryManager::MEMORY_MANAGER_ID;
+
+        return std::move(ref);
+    }
+
+    uint64_t MemoryManager::GetNumBlocks() const
+    {
+        return m_iFreeBlocksBegin;
+    }
+
+    uint8_t* MemoryManager::GetMemory(uint64_t id)
+    {
+        switch (id)
+        {
+            case IMemoryManager::INVALID_ID:
+                return nullptr;
+            case IMemoryManager::MEMORY_MANAGER_ID:
+                return reinterpret_cast<uint8_t*>(this);
+            default:
+                return m_Blocks.at(id).pMemory;
+        }
+    }
+
+    void MemoryManager::FreeBlock(uint64_t iBlock)
+    {
+        switch (iBlock)
+        {
+            case IMemoryManager::INVALID_ID:
+                break; // Equivalent to deleting a nullptr.
+            case IMemoryManager::MEMORY_MANAGER_ID:
+                break; // MemoryManager instance does not use any Block.
+            default:
+                m_FreeCb(m_Blocks.at(iBlock).pMemory - sizeof(BlockHeader));
+                m_Blocks.at(iBlock).pMemory = nullptr;
+
+                // Get the index of the last Block that is not free, in the free Block list.
+                size_t iLastUsedBlock = m_FreeBlockIndices.at(m_iFreeBlocksBegin - 1);
+
+                // Map the Block index to the free Block list.
+                size_t iFreeBlock = m_FreeBlockIndexByBlock.at(iBlock);
+
+                // Swap freed Block with last taken Block before the free Blocks. Since the
+                // number of free Blocks will be decremented, this will push the freed Block
+                // into the free list.
+                std::swap(m_FreeBlockIndices.at(iFreeBlock), m_FreeBlockIndices.at(m_iFreeBlocksBegin - 1));
+
+                // Update the free Block list mapping.
+                std::swap(m_FreeBlockIndexByBlock.at(iBlock), m_FreeBlockIndexByBlock.at(iLastUsedBlock));
+
+                m_iFreeBlocksBegin--;
+                break;
+        }
+    }
+
+    AllocationInfo MemoryManager::Hscpp_Allocate(uint64_t size)
+    {
+        // Performing a generic allocation through hscpp.
+        uint64_t iBlock = ReserveFirstFreeBlock();
+        uint8_t* pMemory = AllocateBlock(size, iBlock);
+
+        AllocationInfo info;
+        info.id = iBlock;
+        info.pMemory = pMemory;
+
+        return info;
+    }
+
+    AllocationInfo MemoryManager::Hscpp_AllocateSwap(uint64_t previousId, uint64_t size)
+    {
+        // Performing a runtime swap of an HSCPP_TRACK object. Reuse the old Block, so that old
+        // Refs will now refer to the newly allocated class.
+        uint64_t iBlock = previousId;
+        AllocateBlock(size, iBlock);
+
+        AllocationInfo info;
+        info.id = iBlock;
+        info.pMemory = m_Blocks.at(iBlock).pMemory;
+
+        return info;
+    }
+
+    uint64_t MemoryManager::Hscpp_FreeSwap(uint8_t* pMemory)
+    {
+        // Performing a free during a runtime swap. Return the old object id so that
+        // HscppAllocateSwap knows the previous id of the deleted object.
+        uint64_t iBlock = reinterpret_cast<BlockHeader*>(pMemory - sizeof(BlockHeader))->iBlock;
+        FreeBlock(iBlock);
+
+        return iBlock;
+    }
+
+    uint8_t* MemoryManager::AllocateBlock(uint64_t size, uint64_t iBlock)
+    {
+        // Allocate sizeof(BlockHeader) extra space, allowing Block info to be saved alongside
+        // the pointer. This makes it possible to quickly find the index during an Hscpp_FreeSwap.
+        uint8_t* pMemory = m_AllocateCb(size + sizeof(BlockHeader));
+
+        reinterpret_cast<BlockHeader*>(pMemory)->iBlock = iBlock;
+
+        // Return memory past the BlockHeader.
+        m_Blocks.at(iBlock).pMemory = pMemory + sizeof(BlockHeader);
+        return m_Blocks.at(iBlock).pMemory;
+    }
+
+    uint64_t MemoryManager::ReserveFirstFreeBlock()
+    {
+        if (m_iFreeBlocksBegin == m_FreeBlockIndices.size())
+        {
+            // No free blocks remain, push back a new one.
+            m_FreeBlockIndices.push_back(m_iFreeBlocksBegin);
+            m_FreeBlockIndexByBlock.push_back(m_iFreeBlocksBegin);
+            m_Blocks.push_back(Block());
+        }
+
+        m_iFreeBlocksBegin++;
+        return m_FreeBlockIndices.at(m_iFreeBlocksBegin - 1);
+    }
+
+    MemoryManager::Config::Config()
+    {
+        AllocateCb = [](uint64_t size) {
+            return new uint8_t[size];
+        };
+
+        FreeCb = [](uint8_t* pMemory) {
+            delete[] pMemory;
+        };
+    }
+}}

--- a/test/unit-tests/CMakeLists.txt
+++ b/test/unit-tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(unit-tests
+list(APPEND HSCPP_UNIT_TEST_SRC_FILES
     Main.cpp
     Test_CmdShell.cpp
     Test_Compiler.cpp
@@ -12,8 +12,16 @@ add_executable(unit-tests
     Test_VarStore.cpp
 )
 
-target_link_libraries(unit-tests
+list(APPEND HSCPP_UNIT_TEST_LINK_LIBRARIES
     catch
     common
     hscpp
 )
+
+if (HSCPP_BUILD_EXTENSION_MEM)
+    list(APPEND HSCPP_UNIT_TEST_SRC_FILES extensions/mem/Test_MemoryManager.cpp)
+    list(APPEND HSCPP_UNIT_TEST_LINK_LIBRARIES hscpp-mem)
+endif()
+
+add_executable(unit-tests ${HSCPP_UNIT_TEST_SRC_FILES})
+target_link_libraries(unit-tests ${HSCPP_UNIT_TEST_LINK_LIBRARIES})

--- a/test/unit-tests/extensions/mem/Test_MemoryManager.cpp
+++ b/test/unit-tests/extensions/mem/Test_MemoryManager.cpp
@@ -1,0 +1,165 @@
+#include <thread>
+
+#include "catch/catch.hpp"
+#include "common/Common.h"
+
+#include "hscpp/mem/MemoryManager.h"
+#include "hscpp/Platform.h"
+#include "hscpp/Util.h"
+#include "hscpp/Hotswapper.h"
+
+namespace hscpp { namespace test {
+
+    template <typename T>
+    using UniqueRef = hscpp::mem::UniqueRef<T>;
+
+    template <typename T>
+    using Ref = hscpp::mem::Ref<T>;
+
+    void RunTest(const std::function<void(UniqueRef<hscpp::mem::MemoryManager>)>& cb)
+    {
+        UniqueRef<hscpp::mem::MemoryManager> rMemoryManager = hscpp::mem::MemoryManager::Create();
+        CALL(cb, std::move(rMemoryManager));
+
+        hscpp::Hotswapper swapper;
+
+        hscpp::mem::MemoryManager::Config config;
+        config.pAllocationResolver = swapper.GetAllocationResolver();
+
+        rMemoryManager = hscpp::mem::MemoryManager::Create(config);
+        swapper.SetAllocator(&rMemoryManager);
+
+        CALL(cb, std::move(rMemoryManager));
+    }
+
+    TEST_CASE("MemoryManager can handle basic allocations.")
+    {
+        auto cb = [](UniqueRef<hscpp::mem::MemoryManager> rMemoryManager){
+            struct Data
+            {
+                int a = 100;
+                double b = 1.5;
+            };
+
+            // Intentional scope.
+            {
+                UniqueRef<Data> rUniqueData = rMemoryManager->Allocate<Data>();
+                REQUIRE(rMemoryManager->GetNumBlocks() == 1);
+                REQUIRE(rUniqueData->a == 100);
+                REQUIRE(rUniqueData->b == 1.5);
+
+                Ref<Data> rData = rUniqueData;
+                REQUIRE(rData->a == 100);
+                REQUIRE(rData->b == 1.5);
+
+                // Both refer to same memory location.
+                rUniqueData->a = 200;
+                rData->b = 2.5;
+
+                REQUIRE(rUniqueData->a == 200);
+                REQUIRE(rUniqueData->b == 2.5);
+                REQUIRE(rData->a == 200);
+                REQUIRE(rData->b == 2.5);
+
+                // New instance moved to rUniqueData.
+                rUniqueData = rMemoryManager->Allocate<Data>();
+                REQUIRE(rMemoryManager->GetNumBlocks() == 1);
+                REQUIRE(rUniqueData->a == 100);
+                REQUIRE(rUniqueData->b == 1.5);
+
+                // Refs refer to freed memory.
+                CHECK_THROWS(rData->a);
+                CHECK_THROWS(rData->b);
+
+                UniqueRef<Data> rMoreUniqueData = rMemoryManager->Allocate<Data>();
+                REQUIRE(rMemoryManager->GetNumBlocks() == 2);
+
+                // The original memory should be reused, so the old Ref should work again. This
+                // is because the MemoryManager will recycle old memory blocks.
+                rUniqueData = std::move(rMoreUniqueData);
+                REQUIRE(rMemoryManager->GetNumBlocks() == 1);
+                REQUIRE(rData->a == 100);
+                REQUIRE(rData->b == 1.5);
+
+                // Data has been moved.
+                CHECK_THROWS(rMoreUniqueData->a);
+                CHECK_THROWS(rMoreUniqueData->b);
+            }
+
+            // UniqueRefs went out of scope.
+            REQUIRE(rMemoryManager->GetNumBlocks() == 0);
+        };
+
+        CALL(RunTest, cb);
+    }
+
+    TEST_CASE("MemoryManager can handle many allocations.")
+    {
+        auto cb = [](UniqueRef<hscpp::mem::MemoryManager> rMemoryManager){
+            struct Data
+            {
+                std::string Str;
+            };
+
+            std::vector<UniqueRef<Data>> data;
+            std::unordered_set<size_t> indices;
+
+            size_t nData = 10000;
+            for (size_t i = 0; i < nData; ++i)
+            {
+                data.push_back(rMemoryManager->Allocate<Data>());
+                data.back()->Str = "Data " + std::to_string(i);
+
+                indices.insert(i);
+            }
+
+            // Do a simple check of all items in list.
+            REQUIRE(rMemoryManager->GetNumBlocks() == nData);
+            for (size_t i = 0; i < nData; ++i)
+            {
+                REQUIRE(data.at(i)->Str == "Data " + std::to_string(i));
+            }
+
+            // Delete items from the list.
+            size_t step = 1;
+            for (size_t i = 0; i < nData; i += step)
+            {
+                data.at(i).Free();
+                indices.erase(i);
+                ++step;
+            }
+
+            for (size_t i = 0; i < nData; ++i)
+            {
+                if (indices.find(i) != indices.end())
+                {
+                    // Validate that non-deleted items still point to same memory locations.
+                    REQUIRE(data.at(i)->Str == "Data " + std::to_string(i));
+                }
+                else
+                {
+                    // Place new memory in freed memory locations.
+                    data.at(i) = rMemoryManager->Allocate<Data>();
+                    data.at(i)->Str = "NewData " + std::to_string(i);
+                }
+            }
+
+            for (size_t i = 0; i < nData; ++i)
+            {
+                if (indices.find(i) != indices.end())
+                {
+                    REQUIRE(data.at(i)->Str == "Data " + std::to_string(i));
+                }
+                else
+                {
+                    REQUIRE(data.at(i)->Str == "NewData " + std::to_string(i));
+                }
+            }
+
+            data.clear();
+            REQUIRE(rMemoryManager->GetNumBlocks() == 0);
+        };
+
+        CALL(RunTest, cb);
+    }
+}}


### PR DESCRIPTION
Adds hscpp-mem, an optional extension which allows for the use of hscpp::mem::MemoryManager and hscpp::mem::Ref. Refs can refer to runtime objects and not have their reference break between runtime swaps.