### PR TITLE
Add hscpp_return statement, to immediately stop Preprocessor.

### DIFF
--- a/docs/8_preprocessor-language.md
+++ b/docs/8_preprocessor-language.md
@@ -52,6 +52,24 @@ For truthiness:
 - Number 0 is false, anything else is true.
 - Bool is either true or false.
 
+## Return statement
+
+The `hscpp_return` statement can be used to immediately stop the Preprocessor. Statements that have already been evaluated will be processed as normal.
+
+For example:
+
+```cpp
+hscpp_require_source("source1")
+
+hscpp_if (var)
+    hscpp_return()
+hscpp_end()
+
+hscpp_require_source("source2")
+```
+
+In the above, if `var` is truthy, only source1 will be added to the compilation list.
+
 ## String interpolation
 
 Variables can also be interpolated within hscpp_require macros, using `${VarName}`.

--- a/include/hscpp/module/PreprocessorMacros.h
+++ b/include/hscpp/module/PreprocessorMacros.h
@@ -13,3 +13,4 @@
 #define hscpp_elif(...)
 #define hscpp_else()
 #define hscpp_end()
+#define hscpp_return()

--- a/include/hscpp/preprocessor/Ast.h
+++ b/include/hscpp/preprocessor/Ast.h
@@ -13,6 +13,7 @@ namespace hscpp
     struct BlockStmt;
     struct IncludeStmt;
     struct HscppIfStmt;
+    struct HscppReturnStmt;
     struct HscppRequireStmt;
     struct HscppModuleStmt;
     struct HscppMessageStmt;
@@ -29,8 +30,9 @@ namespace hscpp
         virtual ~IAstVisitor() = default;
 
         virtual void Visit(const BlockStmt& blockStmt) = 0;
-        virtual void Visit(const HscppIfStmt& ifStmt) = 0;
         virtual void Visit(const IncludeStmt& includeStmt) = 0;
+        virtual void Visit(const HscppIfStmt& ifStmt) = 0;
+        virtual void Visit(const HscppReturnStmt& ifStmt) = 0;
         virtual void Visit(const HscppRequireStmt& requireStmt) = 0;
         virtual void Visit(const HscppModuleStmt& moduleStmt) = 0;
         virtual void Visit(const HscppMessageStmt& messageStmt) = 0;
@@ -69,6 +71,11 @@ namespace hscpp
         std::vector<std::unique_ptr<Expr>> conditions;
         std::vector<std::unique_ptr<BlockStmt>> conditionalBlocks;
         std::unique_ptr<BlockStmt> pElseBlock;
+    };
+
+    struct HscppReturnStmt : public Stmt
+    {
+        void Accept(IAstVisitor& visitor) const override;
     };
 
     struct HscppRequireStmt : public Stmt

--- a/include/hscpp/preprocessor/Interpreter.h
+++ b/include/hscpp/preprocessor/Interpreter.h
@@ -27,6 +27,10 @@ namespace hscpp
         LangError GetLastError();
 
     private:
+        // Thrown to immediately stop interpreter.
+        struct ReturnFromInterpreter
+        {};
+
         const VarStore* m_pVarStore = nullptr;
         Result* m_pResult = nullptr;
 
@@ -37,8 +41,9 @@ namespace hscpp
         void Reset(const VarStore& varStore, Result& result);
 
         void Visit(const BlockStmt& blockStmt) override;
-        void Visit(const HscppIfStmt& ifStmt) override;
         void Visit(const IncludeStmt& includeStmt) override;
+        void Visit(const HscppIfStmt& ifStmt) override;
+        void Visit(const HscppReturnStmt& returnStmt) override;
         void Visit(const HscppRequireStmt& requireStmt) override;
         void Visit(const HscppModuleStmt& moduleStmt) override;
         void Visit(const HscppMessageStmt& messageStmt) override;

--- a/include/hscpp/preprocessor/Parser.h
+++ b/include/hscpp/preprocessor/Parser.h
@@ -45,6 +45,7 @@ namespace hscpp
         std::unique_ptr<BlockStmt> ParseBlockStmt();
         std::unique_ptr<Stmt> ParseIncludeStmt();
         std::unique_ptr<Stmt> ParseHscppIfStmt();
+        std::unique_ptr<Stmt> ParseHscppReturnStmt();
         std::unique_ptr<Stmt> ParseHscppRequireStmt();
         std::unique_ptr<Stmt> ParseHscppModuleStmt();
         std::unique_ptr<Stmt> ParseHscppMessageStmt();

--- a/include/hscpp/preprocessor/Token.h
+++ b/include/hscpp/preprocessor/Token.h
@@ -48,6 +48,7 @@ namespace hscpp
             HscppElif,
             HscppElse,
             HscppEnd,
+            HscppReturn,
 
             HscppTrack,
         };

--- a/src/preprocessor/Ast.cpp
+++ b/src/preprocessor/Ast.cpp
@@ -18,6 +18,11 @@ namespace hscpp
         visitor.Visit(*this);
     }
 
+    void HscppReturnStmt::Accept(IAstVisitor& visitor) const
+    {
+        visitor.Visit(*this);
+    }
+
     void HscppRequireStmt::Accept(IAstVisitor& visitor) const
     {
         visitor.Visit(*this);

--- a/src/preprocessor/Interpreter.cpp
+++ b/src/preprocessor/Interpreter.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 
 #include "hscpp/preprocessor/Interpreter.h"
+#include "hscpp/Platform.h"
 
 namespace hscpp
 {
@@ -13,6 +14,11 @@ namespace hscpp
         try
         {
             rootStmt.Accept(*this);
+        }
+        catch (ReturnFromInterpreter&)
+        {
+            // hscpp_return encountered, exit successfully.
+            return true;
         }
         catch (std::runtime_error&)
         {
@@ -45,6 +51,11 @@ namespace hscpp
         }
     }
 
+    void Interpreter::Visit(const IncludeStmt& includeStmt)
+    {
+        m_pResult->includePaths.push_back(includeStmt.path);
+    }
+
     void Interpreter::Visit(const HscppIfStmt& ifStmt)
     {
         bool bMatchedCondition = false;
@@ -66,9 +77,10 @@ namespace hscpp
         }
     }
 
-    void Interpreter::Visit(const IncludeStmt& includeStmt)
+    void Interpreter::Visit(const HscppReturnStmt& returnStmt)
     {
-        m_pResult->includePaths.push_back(includeStmt.path);
+        HSCPP_UNUSED_PARAM(returnStmt);
+        throw ReturnFromInterpreter();
     }
 
     void Interpreter::Visit(const HscppRequireStmt& requireStmt)

--- a/src/preprocessor/Lexer.cpp
+++ b/src/preprocessor/Lexer.cpp
@@ -19,6 +19,7 @@ namespace hscpp
         { "hscpp_elif", Token::Type::HscppElif },
         { "hscpp_else", Token::Type::HscppElse },
         { "hscpp_end", Token::Type::HscppEnd },
+        { "hscpp_return", Token::Type::HscppReturn },
         { "HSCPP_TRACK", Token::Type::HscppTrack },
         { "true", Token::Type::Bool },
         { "false", Token::Type::Bool },

--- a/src/preprocessor/Parser.cpp
+++ b/src/preprocessor/Parser.cpp
@@ -262,6 +262,9 @@ namespace hscpp
                 case Token::Type::HscppIf:
                     pBlockStmt->statements.push_back(ParseHscppIfStmt());
                     break;
+                case Token::Type::HscppReturn:
+                    pBlockStmt->statements.push_back(ParseHscppReturnStmt());
+                    break;
                 case Token::Type::HscppElif:
                 case Token::Type::HscppElse:
                 case Token::Type::HscppEnd:
@@ -360,6 +363,23 @@ namespace hscpp
         Consume(); // ')'
 
         return pIf;
+    }
+
+    std::unique_ptr<Stmt> Parser::ParseHscppReturnStmt()
+    {
+        auto pReturn = std::unique_ptr<HscppReturnStmt>(new HscppReturnStmt());
+
+        Consume(); // hscpp_return
+
+        Expect(Token::Type::LeftParen, LangError(LangError::Code::Parser_HscppStmtMissingOpeningParen,
+            Peek().line, { "hscpp_return" }));
+        Consume(); // '('
+
+        Expect(Token::Type::RightParen, LangError(LangError::Code::Parser_HscppStmtMissingClosingParen,
+            Peek().line, { "hscpp_return" }));
+        Consume(); // ')'
+
+        return pReturn;
     }
 
     std::unique_ptr<Stmt> Parser::ParseHscppRequireStmt()

--- a/test/unit-tests/Test_Lexer.cpp
+++ b/test/unit-tests/Test_Lexer.cpp
@@ -28,7 +28,7 @@ namespace hscpp { namespace test
             ( ) , == != < <= > >= && || + - / * ! _identifier0 1.0 "str str" #include <map>
             hscpp_require_source hscpp_require_include_dir /*comment*/ hscpp_require_library
             hscpp_require_library_dir hscpp_require_preprocessor_def //comment
-            hscpp_module hscpp_if hscpp_elif hscpp_else hscpp_end
+            hscpp_module hscpp_if hscpp_elif hscpp_else hscpp_end hscpp_return
 
             HSCPP_TRACK
 
@@ -108,6 +108,8 @@ namespace hscpp { namespace test
         REQUIRE(tokens.at(i++).value == "hscpp_else");
         REQUIRE(tokens.at(i).type == Token::Type::HscppEnd);
         REQUIRE(tokens.at(i++).value == "hscpp_end");
+        REQUIRE(tokens.at(i).type == Token::Type::HscppReturn);
+        REQUIRE(tokens.at(i++).value == "hscpp_return");
         REQUIRE(tokens.at(i).type == Token::Type::HscppTrack);
         REQUIRE(tokens.at(i++).value == "HSCPP_TRACK");
         REQUIRE(tokens.at(i).type == Token::Type::Bool);

--- a/test/unit-tests/files/test-preprocessor/require-test/Source1.cpp
+++ b/test/unit-tests/files/test-preprocessor/require-test/Source1.cpp
@@ -8,6 +8,11 @@ int SomeFunction()
 
 hscpp_require_source("Source2.cpp")
 hscpp_if (true)
+
+    hscpp_if (false)
+        hscpp_return()
+    hscpp_end()
+
     hscpp_require_library("lib.lib")
     hscpp_require_library_dir("libdir")
     hscpp_if (num == 2)
@@ -23,3 +28,9 @@ int SomeOtherFunction()
     hscpp_message("message")
     hscpp_module("module")
 }
+
+hscpp_if(2 == 2)
+    hscpp_return()
+hscpp_end()
+
+hscpp_require_preprocessor_def("SHOULD_NOT_BE_ADDED")


### PR DESCRIPTION
hscpp_return can be a useful shortcut to avoid wrapping huge blocks in if statements. It also provides a convenient way to completely disable a file, by placing an unconditional `hscpp_return()` at the top of the file. This is especially useful if DependentCompilation adds files to the compilation list that should be ignored (ex. main.cpp).