### PR TITLE
Do not monitor header folders for changes. Header folders should be added as source directories to add them to the watch

### DIFF
--- a/docs/2_hotswapper-basics.md
+++ b/docs/2_hotswapper-basics.md
@@ -21,7 +21,7 @@ The `Hotswapper` needs to be told where a project's source files are located, vi
 }
 ```
 
-This will cause hscpp to watch the "path/to/src" and "path/to/include" directories for file changes. If a file within one of these directories is modified, hscpp will trigger a recompile.
+This will cause hscpp to watch the "path/to/src" directory for file changes, and search for headers in "path/to/include". If a file within "path/to/src" is changed, a recompilation will be triggered. Note that directories passed to `AddIncludeDirectory` are not monitored for changes. If header file changes should also trigger recompilation, the header folder should additionally be added as a source directory.
 
 In addition to `AddSourceDirectory` and `AddIncludeDirectory`, one can add:
 - `AddLibraryDirectory`

--- a/src/Hotswapper_enabled.cpp
+++ b/src/Hotswapper_enabled.cpp
@@ -247,19 +247,11 @@ namespace hscpp
     int Hotswapper::AddIncludeDirectory(const fs::path& directoryPath)
     {
         m_bDependencyGraphNeedsRefresh = true;
-
-        m_pFileWatcher->AddWatch(directoryPath);
         return Add(directoryPath, m_NextIncludeDirectoryHandle, m_IncludeDirectoryPathsByHandle);
     }
 
     bool Hotswapper::RemoveIncludeDirectory(int handle)
     {
-        auto it = m_IncludeDirectoryPathsByHandle.find(handle);
-        if (it != m_IncludeDirectoryPathsByHandle.end())
-        {
-            m_pFileWatcher->RemoveWatch(it->second);
-        }
-
         bool bRemoved = Remove(handle, m_IncludeDirectoryPathsByHandle);
         if (bRemoved)
         {


### PR DESCRIPTION
It is common to have header includes be for "outer" directories. For example, the folder "hscpp" may have a subdirectory "preprocessor", and files are includes as "hscpp/preprocessor/File.h". It is misleading to add "hscpp" to the watch, as this will not watch subdirectories such as "hscpp/preprocessor" since the watch is non-recursive.