### PR TITLE
Hscpp mem fix

### DIFF
--- a/extensions/mem/include/hscpp/mem/IMemoryManager.h
+++ b/extensions/mem/include/hscpp/mem/IMemoryManager.h
@@ -14,7 +14,7 @@ namespace hscpp { namespace mem {
 
         virtual ~IMemoryManager() = default;
         virtual uint8_t* GetMemory(uint64_t id) = 0;
-        virtual void FreeBlock(uint64_t id) = 0;
+        virtual void FreeBlock(uint64_t id, bool bReleaseReservation) = 0;
     };
 
 }}

--- a/extensions/mem/include/hscpp/mem/MemoryManager.h
+++ b/extensions/mem/include/hscpp/mem/MemoryManager.h
@@ -70,7 +70,7 @@ namespace hscpp { namespace mem {
         // Used by Ref to get underlying memory for a given id. Note that the returned pointer
         // may change for the same id, should a runtime swap take place.
         uint8_t* GetMemory(uint64_t id) override;
-        void FreeBlock(uint64_t iBlock) override;
+        void FreeBlock(uint64_t iBlock, bool bReleaseReservation) override;
 
         // hscpp::IAllocator
         AllocationInfo Hscpp_Allocate(uint64_t size) override;

--- a/extensions/mem/include/hscpp/mem/Ref.h
+++ b/extensions/mem/include/hscpp/mem/Ref.h
@@ -101,7 +101,7 @@ namespace hscpp { namespace mem {
                 if (pSelf != nullptr)
                 {
                     pSelf->~T();
-                    this->m_pMemoryManager->FreeBlock(this->m_Id);
+                    this->m_pMemoryManager->FreeBlock(this->m_Id, true);
                 }
             }
 

--- a/include/hscpp/module/SwapInfo.h
+++ b/include/hscpp/module/SwapInfo.h
@@ -47,13 +47,42 @@ namespace hscpp
         template <typename T>
         void Serialize(const std::string& name, const T& val)
         {
-            m_Serializer.Serialize(name, val);
+            m_Serializer.SerializeCopy(name, val);
         }
 
         template <typename T>
         bool Unserialize(const std::string& name, T& val)
         {
-            return m_Serializer.Unserialize(name, val);
+            return m_Serializer.UnserializeCopy(name, val);
+        }
+
+        template <typename T>
+        void SaveMove(const std::string& name, T&& val)
+        {
+            switch (m_Phase)
+            {
+                case SwapPhase::BeforeSwap:
+                    SerializeMove(name, std::move(val));
+                    break;
+                case SwapPhase::AfterSwap:
+                    Unserialize(name, val);
+                    break;
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+
+        template <typename T>
+        void SerializeMove(const std::string& name, T&& val)
+        {
+            m_Serializer.SerializeMove(name, std::move(val));
+        }
+
+        template <typename T>
+        bool UnserializeMove(const std::string& name, T& val)
+        {
+            return m_Serializer.UnserializeMove(name, val);
         }
 
     private:

--- a/test/unit-tests/CMakeLists.txt
+++ b/test/unit-tests/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND HSCPP_UNIT_TEST_SRC_FILES
     Test_Lexer.cpp
     Test_Parser.cpp
     Test_Preprocessor.cpp
+    Test_SwapInfo.cpp
     Test_VarStore.cpp
 )
 

--- a/test/unit-tests/Test_SwapInfo.cpp
+++ b/test/unit-tests/Test_SwapInfo.cpp
@@ -1,0 +1,77 @@
+#include "catch/catch.hpp"
+#include "common/Common.h"
+#include "hscpp/module/SwapInfo.h"
+
+namespace hscpp { namespace test
+{
+
+    TEST_CASE("SwapInfo can serialize and unserialize copyable items.")
+    {
+        int nBytes = 100;
+        uint8_t* pMemory = new uint8_t[nBytes];
+
+        struct Data
+        {
+            float float1 = 0;
+            float float2 = 0;
+        };
+
+        Data data;
+        data.float1 = -20;
+        data.float2 = 7777;
+
+        hscpp::SwapInfo info;
+
+        info.Serialize("nBytes", nBytes);
+        info.Serialize("pMemory", pMemory);
+        info.Serialize("data", data);
+
+        int nBytesUnserialized = 0;
+        uint8_t* pMemoryUnserialized = nullptr;
+        Data dataUnserialized;
+
+        info.Unserialize("nBytes", nBytesUnserialized);
+        info.Unserialize("pMemory", pMemoryUnserialized);
+        info.Unserialize("data", dataUnserialized);
+
+        REQUIRE(nBytes == nBytesUnserialized);
+        REQUIRE(pMemory == pMemoryUnserialized);
+        REQUIRE(data.float1 == dataUnserialized.float1);
+        REQUIRE(data.float2 == dataUnserialized.float2);
+
+        delete[] pMemory;
+    }
+
+    TEST_CASE("SwapInfo can serialize and unserialize movable items.")
+    {
+        struct InnerData
+        {
+            int int1;
+        };
+
+        struct Data
+        {
+            float float1 = 0;
+            float float2 = 0;
+
+            std::unique_ptr<InnerData> pInnerData;
+        };
+
+        auto pData = std::unique_ptr<Data>(new Data());
+        pData->float1 = 55;
+        pData->float2 = 66;
+        pData->pInnerData = std::unique_ptr<InnerData>(new InnerData());
+        pData->pInnerData->int1 = 77;
+
+        hscpp::SwapInfo info;
+        std::unique_ptr<Data> pDataUnserialized;
+
+        info.SerializeMove("pData", std::move(pData));
+        info.UnserializeMove("pData", pDataUnserialized);
+
+        REQUIRE(pDataUnserialized->float1 == 55);
+        REQUIRE(pDataUnserialized->float2 == 66);
+        REQUIRE(pDataUnserialized->pInnerData->int1 == 77);
+    }
+
+}}


### PR DESCRIPTION
- Fixes bug with Hscpp_FreeSwap, by not releasing reserved block.
- It was noted that it was impossible to serialize a UniqueRef (or, for that matter, a std::unique_ptr) with SwapInfo. This adds the ability to serialize movable objects.