### PR TITLE
[GH-15] Fix not handling escaped slashes in string literal.

### DIFF
--- a/src/preprocessor/Lexer.cpp
+++ b/src/preprocessor/Lexer.cpp
@@ -250,8 +250,16 @@ namespace hscpp
                 Advance();
                 str += '"';
             }
+            else if (Peek() == '\\' && PeekNext() == '\\')
+            {
+                // Escaped slash.
+                Advance();
+                Advance();
+                str += '\\';
+            }
             else
             {
+                // Not handling other escape sequences (ex. \n).
                 str += Peek();
                 Advance();
             }

--- a/test/unit-tests/Test_Lexer.cpp
+++ b/test/unit-tests/Test_Lexer.cpp
@@ -179,7 +179,7 @@ namespace hscpp { namespace test
     TEST_CASE("Lexer can lex various strings.")
     {
         std::string str = R"(
-            "Hello, World!" "" "F" "@!(*$&"
+            "Hello, World!" "" "F" "@!(*$&"  "\\"
         )";
 
         std::vector<Token> tokens;
@@ -198,6 +198,9 @@ namespace hscpp { namespace test
 
         REQUIRE(tokens.at(3).type == Token::Type::String);
         REQUIRE(tokens.at(3).value == "@!(*$&");
+
+        REQUIRE(tokens.at(4).type == Token::Type::String);
+        REQUIRE(tokens.at(4).value == "\\");
     }
 
     TEST_CASE("Lexer can lex various includes.")


### PR DESCRIPTION
Addresses https://github.com/jheruty/hscpp/issues/15

The Lexer was not correctly handling escaped slashes in string literals, causing unterminated string errors.