### PR TITLE
Improve error message for unterminated strings, including the start line and the string's beginning.

### DIFF
--- a/include/hscpp/preprocessor/LangError.h
+++ b/include/hscpp/preprocessor/LangError.h
@@ -16,7 +16,7 @@ namespace hscpp
         {
             Success,                                                                //
                                                                                     //
-            Lexer_UnterminatedString,                                               // (expected)
+            Lexer_UnterminatedString,                                               // (expected, start_line, beginning_of_string)
                                                                                     //
             Parser_FailedToParsePrefixExpression,                                   // (op)
             Parser_FailedToParseInfixExpression,                                    // (op)

--- a/src/preprocessor/LangError.cpp
+++ b/src/preprocessor/LangError.cpp
@@ -9,7 +9,7 @@ namespace hscpp
     const static std::unordered_map<LangError::Code, std::string, LangErrorCodeHasher> ERRORS = {
         { LangError::Code::Success, "" },
 
-        { LangError::Code::Lexer_UnterminatedString, "Unterminated string, expected a '$1'." },
+        { LangError::Code::Lexer_UnterminatedString, "Unterminated string, expected a '$1'. String opens on line $2, beginning with '$3'." },
 
         { LangError::Code::Parser_FailedToParsePrefixExpression, "'$1' is not a supported unary operator." },
         { LangError::Code::Parser_FailedToParseInfixExpression, "'$1' is not a supported binary operator." },

--- a/src/preprocessor/Lexer.cpp
+++ b/src/preprocessor/Lexer.cpp
@@ -237,6 +237,7 @@ namespace hscpp
 
     void Lexer::LexString(char endChar)
     {
+        size_t startLine = m_Line;
         std::string str;
 
         Advance(); // Skip opening '"' or '<'.
@@ -267,8 +268,10 @@ namespace hscpp
 
         if (Peek() != endChar)
         {
+            // Note that error includes start line and beginning of string, to make it easier to
+            // determine the problematic string (m_Line and m_Column will point to end of file).
             ThrowError(LangError(LangError::Code::Lexer_UnterminatedString,
-                    m_Line, m_Column, { std::string(1, endChar) }));
+                    m_Line, m_Column, { std::string(1, endChar), std::to_string(startLine), str.substr(0, 10) }));
         }
 
         Advance();

--- a/test/unit-tests/Test_Lexer.cpp
+++ b/test/unit-tests/Test_Lexer.cpp
@@ -263,13 +263,20 @@ namespace hscpp { namespace test
     TEST_CASE("Lexer handles errors correctly.")
     {
         std::vector<Token> tokens;
-        Lexer lexer;
 
         CALL(ValidateError, "\n\n\nhscpp_include(\"unterminated string);",
-            LangError::Code::Lexer_UnterminatedString, 4, { "\"" });
+            LangError::Code::Lexer_UnterminatedString, 4, { "\"", "4", "unterminat" });
 
+        // Adding a raw newline.
         CALL(ValidateError, "#include \"Good.h\"\n#include <bad\nhscpp_module(\"module\")",
-            LangError::Code::Lexer_UnterminatedString, 3, { ">" });
+            LangError::Code::Lexer_UnterminatedString, 3, { ">", "2", "bad\nhscpp_" });
+
+        // Currently, only \" and \\ escape sequences are handled.
+        CALL(ValidateError, R"("\n\n\"\\)",
+            LangError::Code::Lexer_UnterminatedString, 1, { "\"", "1", R"(\n\n"\)" });
+
+        CALL(ValidateError, "\"",
+            LangError::Code::Lexer_UnterminatedString, 1, { "\"", "1", "" });
     }
 
 }}


### PR DESCRIPTION
https://github.com/jheruty/hscpp/issues/15

The error message for the "unterminated string" error was confusing, as this would only be caught at the end of the file. Add the start line and the beginning of the string to make the error more readable. 