### PR TITLE
Visual Studio 2022 support and various fixes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    - cron: "0 10 * * *" # 2AM PST
+    - cron: "0 10 1 * *" # 2AM PST, on 1st of every month.
 
 env:
   build_directory: "${{ github.workspace }}/../../build"

--- a/include/hscpp/Config.h
+++ b/include/hscpp/Config.h
@@ -14,7 +14,7 @@ namespace hscpp
         CompilerConfig();
 
         int cppStandard = HSCPP_CXX_STANDARD;
-        std::chrono::milliseconds initializeTimeout = std::chrono::milliseconds(10000);
+        std::chrono::milliseconds initializeTimeout = std::chrono::milliseconds(60000);
 
         fs::path executable;
     };

--- a/include/hscpp/Log.h
+++ b/include/hscpp/Log.h
@@ -63,7 +63,7 @@ namespace hscpp { namespace log
     class Stream
     {
     public:
-        explicit Stream(bool bEnabled, const std::function<void(const std::wstringstream&)>& endCb = nullptr);
+        explicit Stream(bool bEnabled, const std::function<void(const std::stringstream&)>& endCb = nullptr);
         Stream& operator<<(const std::string& str);
 
         Stream& operator<<(const LastOsError& lastError);
@@ -84,9 +84,9 @@ namespace hscpp { namespace log
 
     private:
         bool m_bEnabled = true;
-        std::function<void(const std::wstringstream&)> m_EndCb;
+        std::function<void(const std::stringstream&)> m_EndCb;
 
-        std::wstringstream m_Stream;
+        std::stringstream m_Stream;
     };
 
     //============================================================================

--- a/include/hscpp/Platform.h
+++ b/include/hscpp/Platform.h
@@ -49,16 +49,16 @@ typedef int TOsError;
         std::vector<std::string> GetDefaultPreprocessorDefinitions();
         fs::path GetDefaultCompilerExecutable();
 
-        void WriteDebugString(const std::wstring& str);
+        void WriteDebugString(const std::string& str);
         std::string CreateGuid();
 
 #if defined(HSCPP_PLATFORM_WIN32)
-        std::wstring GetErrorString(TOsError error);
-        std::wstring GetLastErrorString();
+        std::string GetErrorString(TOsError error);
+        std::string GetLastErrorString();
 
 #elif defined(HSCPP_PLATFORM_UNIX)
-        std::wstring GetErrorString(TOsError error);
-        std::wstring GetLastErrorString();
+        std::string GetErrorString(TOsError error);
+        std::string GetLastErrorString();
 #endif
 
         std::string GetSharedLibraryExtension();

--- a/include/hscpp/Util.h
+++ b/include/hscpp/Util.h
@@ -12,6 +12,7 @@ namespace hscpp { namespace util
 
     bool IsWhitespace(const std::string& str);
     std::string Trim(const std::string& str);
+    std::string Quote(const std::string& str);
 
     std::string UnixSlashes(const std::string& str);
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -30,7 +30,7 @@ namespace hscpp { namespace log
         return m_ErrorCode;
     }
 
-    Stream::Stream(bool bEnabled, const std::function<void(const std::wstringstream&)>& endCb /* = nullptr */)
+    Stream::Stream(bool bEnabled, const std::function<void(const std::stringstream&)>& endCb /* = nullptr */)
         : m_bEnabled(bEnabled)
         , m_EndCb(endCb)
     {}
@@ -42,10 +42,7 @@ namespace hscpp { namespace log
             return *this;
         }
 
-        std::wstring ws(str.size(), L' ');
-        ws.resize(std::mbstowcs(&ws[0], str.c_str(), str.size()));
-
-        m_Stream << ws;
+        m_Stream << str;
         return *this;
     }
 
@@ -58,7 +55,7 @@ namespace hscpp { namespace log
             return *this;
         }
 
-        m_Stream << L"[" << platform::GetLastErrorString() << L"]";
+        m_Stream << "[" << platform::GetLastErrorString() << "]";
         return *this;
     }
 
@@ -69,7 +66,7 @@ namespace hscpp { namespace log
             return *this;
         }
 
-        m_Stream << L"[" << platform::GetErrorString(osError.ErrorCode()) << L"]";
+        m_Stream << "[" << platform::GetErrorString(osError.ErrorCode()) << "]";
         return *this;
     }
 
@@ -81,7 +78,7 @@ namespace hscpp { namespace log
         }
 
         *this << endLog.Str();
-        std::wcout << m_Stream.str() << std::endl;
+        std::cout << m_Stream.str() << std::endl;
 
         if (m_EndCb != nullptr)
         {
@@ -121,7 +118,7 @@ namespace hscpp { namespace log
     Stream Build()
     {
         // Direct logs to debugger output.
-        return Stream(s_bLogBuild, [](const std::wstringstream& stream) {
+        return Stream(s_bLogBuild, [](const std::stringstream& stream) {
             platform::WriteDebugString(stream.str());
         });
     }

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -199,10 +199,10 @@ namespace hscpp { namespace platform
     // Utilities
     //============================================================================
 
-    void WriteDebugString(const std::wstring& str)
+    void WriteDebugString(const std::string& str)
     {
 #if defined(HSCPP_PLATFORM_WIN32)
-        OutputDebugStringW(str.c_str());
+        OutputDebugString(str.c_str());
 #else
         HSCPP_UNUSED_PARAM(str);
 #endif
@@ -241,24 +241,24 @@ namespace hscpp { namespace platform
 
 #if defined(HSCPP_PLATFORM_WIN32)
 
-    std::wstring GetErrorString(TOsError error)
+    std::string GetErrorString(TOsError error)
     {
         if (error == ERROR_SUCCESS)
         {
-            return L""; // No error.
+            return ""; // No error.
         }
 
-        LPWSTR buffer = nullptr;
-        size_t size = FormatMessageW(
+        LPVOID buffer = nullptr;
+        size_t size = FormatMessage(
             FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             NULL,
             error,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            reinterpret_cast<LPWSTR>(&buffer),
+            reinterpret_cast<LPTSTR>(&buffer),
             0,
             NULL);
 
-        std::wstring message(buffer, size);
+        std::string message(static_cast<char*>(buffer), size);
         LocalFree(buffer);
 
         // Remove trailing '\r\n'.
@@ -273,20 +273,19 @@ namespace hscpp { namespace platform
         return message;
     }
 
-    std::wstring GetLastErrorString()
+    std::string GetLastErrorString()
     {
         return GetErrorString(GetLastError());
     }
 
 #elif defined(HSCPP_PLATFORM_UNIX)
 
-    std::wstring GetErrorString(TOsError error)
+    std::string GetErrorString(TOsError error)
     {
-        std::string errorStr = strerror(error);
-        return std::wstring(errorStr.begin(), errorStr.end());
+        return strerror(error);
     }
 
-    std::wstring GetLastErrorString()
+    std::string GetLastErrorString()
     {
         return GetErrorString(errno);
     }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -42,6 +42,11 @@ namespace hscpp { namespace util
         return "";
     }
 
+    std::string Quote(const std::string& str)
+    {
+        return "\"" + str + "\"";
+    }
+
     std::string UnixSlashes(const std::string& str)
     {
         std::string replacedStr = str;

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -25,12 +25,14 @@ namespace hscpp
             return;
         }
 
+        log::Info() << HSCPP_LOG_PREFIX << "Initializing compiler." << log::End();
         m_pInitializeTask->Start(m_pCmdShell.get(), m_pConfig->initializeTimeout,
                 [&](ICmdShellTask::Result result){
             switch (result)
             {
                 case ICmdShellTask::Result::Success:
                     m_bInitialized = true;
+                    log::Info() << HSCPP_LOG_PREFIX << "Compiler has been initialized successfully." << log::End();
                     break;
                 case ICmdShellTask::Result::Failure:
                     m_bInitializationFailed = true;

--- a/src/compiler/CompilerInitializeTask_msvc.cpp
+++ b/src/compiler/CompilerInitializeTask_msvc.cpp
@@ -76,13 +76,13 @@ namespace hscpp
 
         switch (_MSC_VER)
         {
-			case 1900:
-				compilerVersion = "14.0";
-				break;
-			case 1910:
-			case 1911:
-			case 1912:
-			case 1913:
+            case 1900:
+                compilerVersion = "14.0";
+                break;
+            case 1910:
+            case 1911:
+            case 1912:
+            case 1913:
             case 1914:
             case 1915:
             case 1916:
@@ -96,7 +96,7 @@ namespace hscpp
             case 1925:
             case 1926:
             case 1927:
-			case 1928:
+            case 1928:
                 compilerVersion = "16.0";
                 break;
             default:
@@ -105,80 +105,80 @@ namespace hscpp
                 break;
         }
 
-		if (compilerVersion == "14.0")
-		{
-			// VS2015 stores installation path in registry key.
-			HKEY registryKey;
-			std::string registryName = "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7";
-			
-			LSTATUS result = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-				registryName.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &registryKey);
+        if (compilerVersion == "14.0")
+        {
+            // VS2015 stores installation path in registry key.
+            HKEY registryKey;
+            std::string registryName = "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7";
+            
+            LSTATUS result = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                registryName.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &registryKey);
 
-			if (result != HSCPP_ERROR_SUCCESS)
-			{
-				log::Error() << HSCPP_LOG_PREFIX << "Failed to open registry key '"
-					<< registryName << "'." << log::OsError(result) << log::End();
-				return;
-			}
+            if (result != HSCPP_ERROR_SUCCESS)
+            {
+                log::Error() << HSCPP_LOG_PREFIX << "Failed to open registry key '"
+                    << registryName << "'." << log::OsError(result) << log::End();
+                return;
+            }
 
-			char vsPath[MAX_PATH];
-			DWORD size = sizeof(vsPath);
-			
-			result = RegQueryValueEx(registryKey, "14.0", nullptr, nullptr, reinterpret_cast<LPBYTE>(vsPath), &size);
-			if (result != HSCPP_ERROR_SUCCESS)
-			{
-				log::Error() << HSCPP_LOG_PREFIX << "Failed to read registry key value."
-					<< log::OsError(result) << log::End();
-				return;
-			}
+            char vsPath[MAX_PATH];
+            DWORD size = sizeof(vsPath);
+            
+            result = RegQueryValueEx(registryKey, "14.0", nullptr, nullptr, reinterpret_cast<LPBYTE>(vsPath), &size);
+            if (result != HSCPP_ERROR_SUCCESS)
+            {
+                log::Error() << HSCPP_LOG_PREFIX << "Failed to read registry key value."
+                    << log::OsError(result) << log::End();
+                return;
+            }
 
-			if (!StartVcVarsAllTask(vsPath, "VC"))
-			{
-				log::Error() << HSCPP_LOG_PREFIX << "Failed to start vcvarsall task." << log::End();
-				return;
-			}
-		}
-		else
-		{
-			// VS2017 and up ships with vswhere.exe, which can be used to find the Visual Studio install path.
-			std::string query = "\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere\""
-				" -version " + compilerVersion +
-				" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-				" -property installationPath";
+            if (!StartVcVarsAllTask(vsPath, "VC"))
+            {
+                log::Error() << HSCPP_LOG_PREFIX << "Failed to start vcvarsall task." << log::End();
+                return;
+            }
+        }
+        else
+        {
+            // VS2017 and up ships with vswhere.exe, which can be used to find the Visual Studio install path.
+            std::string query = "\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere\""
+                " -version " + compilerVersion +
+                " -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+                " -property installationPath";
 
-			m_pCmdShell->StartTask(query, static_cast<int>(CompilerTask::GetVsPath));
-		}
+            m_pCmdShell->StartTask(query, static_cast<int>(CompilerTask::GetVsPath));
+        }
     }
 
-	bool CompilerInitializeTask_msvc::StartVcVarsAllTask(const fs::path& vsPath, const fs::path& vcVarsAllDirectoryPath)
-	{
-		fs::path vcVarsAllPath = vsPath / vcVarsAllDirectoryPath / "vcvarsall.bat";
-		if (!fs::exists(vcVarsAllPath))
-		{
-			log::Error() << HSCPP_LOG_PREFIX
-				<< "Could not find vcvarsall.bat in path " << vcVarsAllPath << log::End(".");
-			return false;
-		}
+    bool CompilerInitializeTask_msvc::StartVcVarsAllTask(const fs::path& vsPath, const fs::path& vcVarsAllDirectoryPath)
+    {
+        fs::path vcVarsAllPath = vsPath / vcVarsAllDirectoryPath / "vcvarsall.bat";
+        if (!fs::exists(vcVarsAllPath))
+        {
+            log::Error() << HSCPP_LOG_PREFIX
+                << "Could not find vcvarsall.bat in path " << vcVarsAllPath << log::End(".");
+            return false;
+        }
 
-		std::string command = "\"" + vcVarsAllPath.string() + "\"";
+        std::string command = "\"" + vcVarsAllPath.string() + "\"";
 
-		// Determine whether we are running in 32 or 64 bit.
-		switch (sizeof(void*))
-		{
-		case 4:
-			command += " x86";
-			break;
-		case 8:
-			command += " x86_amd64";
-			break;
-		default:
-			assert(false); // It must be the future!
-			break;
-		}
+        // Determine whether we are running in 32 or 64 bit.
+        switch (sizeof(void*))
+        {
+        case 4:
+            command += " x86";
+            break;
+        case 8:
+            command += " x86_amd64";
+            break;
+        default:
+            assert(false); // It must be the future!
+            break;
+        }
 
-		m_pCmdShell->StartTask(command, static_cast<int>(CompilerTask::SetVcVarsAll));
-		return true;
-	}
+        m_pCmdShell->StartTask(command, static_cast<int>(CompilerTask::SetVcVarsAll));
+        return true;
+    }
 
     void CompilerInitializeTask_msvc::HandleTaskComplete(CompilerTask task)
     {
@@ -229,13 +229,13 @@ namespace hscpp
             return;
         }
 
-		if (!StartVcVarsAllTask(bestVsPath, "VC/Auxiliary/Build"))
-		{
-			log::Error() << HSCPP_LOG_PREFIX << "Failed to start vcvarsall task." << log::End();
+        if (!StartVcVarsAllTask(bestVsPath, "VC/Auxiliary/Build"))
+        {
+            log::Error() << HSCPP_LOG_PREFIX << "Failed to start vcvarsall task." << log::End();
 
             TriggerDoneCb(Result::Failure);
             return;
-		}
+        }
     }
 
     void CompilerInitializeTask_msvc::HandleSetVcVarsAllTaskComplete(

--- a/src/compiler/CompilerInitializeTask_msvc.cpp
+++ b/src/compiler/CompilerInitializeTask_msvc.cpp
@@ -71,8 +71,8 @@ namespace hscpp
     void CompilerInitializeTask_msvc::StartVsPathTask()
     {
         // https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019
-        // Find the matching compiler version. Versions supported: VS2015, VS2017, VS2019
-        std::string compilerVersion = "16.0";
+        // Find the matching compiler version. Versions supported: VS2015, VS2017, VS2019, VS2022
+        std::string compilerVersion = "17.0";
 
         switch (_MSC_VER)
         {
@@ -97,7 +97,13 @@ namespace hscpp
             case 1926:
             case 1927:
             case 1928:
+            case 1929:
                 compilerVersion = "16.0";
+                break;
+            case 1930:
+            case 1931:
+            case 1932:
+                compilerVersion = "17.0";
                 break;
             default:
                 log::Warning() << HSCPP_LOG_PREFIX << "Unknown compiler version, using default version '"

--- a/src/file-watcher/FileWatcher_win32.cpp
+++ b/src/file-watcher/FileWatcher_win32.cpp
@@ -146,6 +146,14 @@ namespace hscpp
             return;
         }
 
+        if (nBytesTransferred == 0)
+        {
+            // Most likely related to:
+            // https://stackoverflow.com/questions/43664998/readdirectorychangesw-and-getoverlappedresult
+            // The data is not ready yet. Just return quietly.
+            return;
+        }
+
         FILE_NOTIFY_INFORMATION* pNotify = nullptr;
         DirectoryWatch* pWatch = reinterpret_cast<DirectoryWatch*>(overlapped);
 

--- a/test/integration-tests/IntegrationTest.cpp
+++ b/test/integration-tests/IntegrationTest.cpp
@@ -23,7 +23,7 @@ namespace hscpp { namespace test
         m_pCmdShell = platform::CreateCmdShell();
         REQUIRE(m_pCmdShell->CreateCmdProcess());
 
-        std::string task = fs::path(TEST_BUILD_PATH / testName / configuration / testName).u8string();
+        std::string task = util::Quote(fs::path(TEST_BUILD_PATH / testName / configuration / testName).u8string());
         m_pCmdShell->StartTask(task, 0);
 
         WaitForLog("[LOADED]:");

--- a/test/integration-tests/Main.cpp
+++ b/test/integration-tests/Main.cpp
@@ -40,7 +40,7 @@ namespace hscpp { namespace test {
     TEST_CASE("Integration test 'simple-printer-test' passes.")
     {
         IntegrationTest test;
-        CALL(test.Init, "simple-printer-test", configuration, Milliseconds(30000));
+        CALL(test.Init, "simple-printer-test", configuration, Milliseconds(60000));
 
         CALL(test.VerifyResult, "Printer update - original code. Count: 0");
         CALL(test.VerifyResult, "Printer update - original code. Count: 1");


### PR DESCRIPTION
- Adds support for Visual Studio 2022.
- Increases timeout for compiler initialization, since VS2022 takes significantly longer to start up.
- Fix integration test by quoting path.
- Return in Win32 file watcher callback if nBytesTransferred is zero. This indicates the data isn't ready, and the lack of this check was causing invalid memory reads.
- Switch from std::wstring to std::string in logging, to avoid mixed std::wcout and std::cout which is undefined.
- Reduce GitHub action schedule to once a month.