### PR TITLE
Locate and add library

### DIFF
--- a/examples/imgui-demo/src/Main.cpp
+++ b/examples/imgui-demo/src/Main.cpp
@@ -95,7 +95,8 @@ int main(int, char**)
     swapper.AddIncludeDirectory(includePath);
     swapper.AddIncludeDirectory(exampleUtilsIncludePath);
     swapper.AddIncludeDirectory(imguiIncludePath);
-    swapper.AddLibrary(hscpp::util::FindFile(DEMO_BUILD_PATH, imguiLibraryName));
+
+    swapper.LocateAndAddLibrary(DEMO_BUILD_PATH, imguiLibraryName);
     swapper.LocateAndAddLibrary(HSCPP_EXAMPLE_UTILS_BUILD_PATH, exampleUtilsLibraryName);
 
     GLFWwindow* pWindow = nullptr;

--- a/examples/imgui-demo/src/Main.cpp
+++ b/examples/imgui-demo/src/Main.cpp
@@ -84,19 +84,19 @@ int main(int, char**)
     auto imguiIncludePath = DEMO_CODE_PATH / "lib" / "imgui";
 
 #ifdef _WIN32
-    auto imguiLibraryPath = DEMO_BUILD_PATH / "lib" / "imgui" / "imgui.lib";
-    auto exampleUtilsLibraryPath = HSCPP_EXAMPLE_UTILS_BUILD_PATH / "hscpp-example-utils.lib";
+    auto imguiLibraryName = "imgui.lib";
+    auto exampleUtilsLibraryName =  "hscpp-example-utils.lib";
 #else
-    auto imguiLibraryPath = DEMO_BUILD_PATH / "lib" / "imgui" / "libimgui.a";
-    auto exampleUtilsLibraryPath = HSCPP_EXAMPLE_UTILS_BUILD_PATH / "libhscpp-example-utils.a";
+    auto imguiLibraryName = "imgui.a";
+    auto exampleUtilsLibraryName =  "hscpp-example-utils.a";
 #endif
 
     swapper.AddSourceDirectory(srcPath);
     swapper.AddIncludeDirectory(includePath);
     swapper.AddIncludeDirectory(exampleUtilsIncludePath);
     swapper.AddIncludeDirectory(imguiIncludePath);
-    swapper.AddLibrary(imguiLibraryPath);
-    swapper.AddLibrary(exampleUtilsLibraryPath);
+    swapper.AddLibrary(hscpp::util::FindFile(DEMO_BUILD_PATH, imguiLibraryName));
+    swapper.LocateAndAddLibrary(HSCPP_EXAMPLE_UTILS_BUILD_PATH, exampleUtilsLibraryName);
 
     GLFWwindow* pWindow = nullptr;
     if (!SetupGlfw(pWindow))

--- a/include/hscpp/Hotswapper.h
+++ b/include/hscpp/Hotswapper.h
@@ -85,6 +85,7 @@ namespace hscpp
         void ClearLibraryDirectories();
 
         int AddLibrary(const fs::path& libraryPath);
+        int LocateAndAddLibrary(const fs::path& rootPath, const fs::path& libraryName);
         bool RemoveLibrary(int handle);
         void EnumerateLibraries(const std::function<void(int handle, const fs::path& libraryPath)>& cb);
         void ClearLibraries();

--- a/include/hscpp/Util.h
+++ b/include/hscpp/Util.h
@@ -27,6 +27,8 @@ namespace hscpp { namespace util
     fs::path GetHscppBuildExamplesPath();
     fs::path GetHscppBuildTestPath();
 
+    fs::path FindFile(const fs::path& rootPath, const fs::path& name);
+
     void SortFileEvents(const std::vector<IFileWatcher::Event>& events,
                         std::vector<fs::path>& canonicalModifiedFilePaths,
                         std::vector<fs::path>& canonicalRemovedFilePaths);

--- a/src/Hotswapper_disabled.cpp
+++ b/src/Hotswapper_disabled.cpp
@@ -142,6 +142,11 @@ namespace hscpp
         return -1;
     }
 
+    int Hotswapper::LocateAndAddLibrary(const fs::path& rootPath, const fs::path& libraryName)
+    {
+        return -1;
+    }
+
     bool Hotswapper::RemoveLibrary(int)
     {
         return false;

--- a/src/Hotswapper_enabled.cpp
+++ b/src/Hotswapper_enabled.cpp
@@ -352,6 +352,12 @@ namespace hscpp
         return Add(libraryPath, m_NextLibraryHandle, m_LibraryPathsByHandle);
     }
 
+    int Hotswapper::LocateAndAddLibrary(const fs::path& rootPath, const fs::path& libraryName)
+    {
+        auto result = util::FindFile(rootPath, libraryName);
+        return Add(result, m_NextLibraryHandle, m_LibraryPathsByHandle);
+    }
+
     bool Hotswapper::RemoveLibrary(int handle)
     {
         return Remove(handle, m_LibraryPathsByHandle);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -155,4 +155,27 @@ namespace hscpp { namespace util
                 dedupedRemovedFilePaths.begin(), dedupedRemovedFilePaths.end());
     }
 
+    fs::path FindFile(const fs::path& rootPath, const fs::path& name)
+    {
+        if (!fs::exists(rootPath)) {
+            return fs::path();
+        }
+
+        fs::path directory = fs::canonical(rootPath);
+
+        for (const auto& entry : fs::recursive_directory_iterator(directory)) {
+            if (entry.is_regular_file()) {
+                if (fs::exists(entry)) {
+                    if (entry.path().filename().compare(name) == 0) {
+                        return entry.path();
+                    }
+                }
+            }
+        }
+
+        log::Warning() << "Unable to find file " << name << " within " << directory << log::End();
+
+        return fs::path();
+    }
+
 }}

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -173,7 +173,7 @@ namespace hscpp { namespace util
             }
         }
 
-        log::Warning() << "Unable to find file " << name << " within " << directory << log::End();
+        log::Warning() << HSCPP_LOG_PREFIX << "Unable to find file " << name << " within " << directory << log::End();
 
         return fs::path();
     }


### PR DESCRIPTION
This pull request adds a LocateAndAddLibrary method to the hotswapper class. This allows us to locate a library inside a sub directory before adding it which is useful in cases where we cannot be sure where a build system will build said library (ie. MSVC was buildimg imgui.lib inside `PROJECT_DIR/libs/imgui/Debug` instead of `PROJECT_DIR/libs/imgui`).